### PR TITLE
[Populate] Generate experiments for namesMappedToCohorts

### DIFF
--- a/Switchboard.xcodeproj/project.pbxproj
+++ b/Switchboard.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		D4E07F9C1F71BAE0003F5A89 /* SwitchboardSubclassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E07F9B1F71BAE0003F5A89 /* SwitchboardSubclassTests.swift */; };
 		D4E07FAC1F71C3A4003F5A89 /* SwitchboardCacheable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E07FAB1F71C3A4003F5A89 /* SwitchboardCacheable.swift */; };
 		D4E07FAF1F71C436003F5A89 /* SwitchboardCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E07FAE1F71C436003F5A89 /* SwitchboardCache.swift */; };
+		D4EB06CA2072BDB0005DAACC /* SwitchboardPrefillControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EB06C92072BDB0005DAACC /* SwitchboardPrefillControllerTests.swift */; };
 		D4F26D9F1F741C7F006D2FA0 /* SwitchboardLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F26D9E1F741C7F006D2FA0 /* SwitchboardLogging.swift */; };
 		D4F26DA91F743168006D2FA0 /* SwitchboardProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F26DA81F743168006D2FA0 /* SwitchboardProperties.swift */; };
 		D4F26DAB1F743483006D2FA0 /* SwitchboardPropertiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F26DAA1F743483006D2FA0 /* SwitchboardPropertiesTests.swift */; };
@@ -178,6 +179,7 @@
 		D4E07F9B1F71BAE0003F5A89 /* SwitchboardSubclassTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchboardSubclassTests.swift; sourceTree = "<group>"; };
 		D4E07FAB1F71C3A4003F5A89 /* SwitchboardCacheable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchboardCacheable.swift; sourceTree = "<group>"; };
 		D4E07FAE1F71C436003F5A89 /* SwitchboardCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchboardCache.swift; sourceTree = "<group>"; };
+		D4EB06C92072BDB0005DAACC /* SwitchboardPrefillControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchboardPrefillControllerTests.swift; sourceTree = "<group>"; };
 		D4F26D9E1F741C7F006D2FA0 /* SwitchboardLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchboardLogging.swift; sourceTree = "<group>"; };
 		D4F26DA81F743168006D2FA0 /* SwitchboardProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchboardProperties.swift; sourceTree = "<group>"; };
 		D4F26DAA1F743483006D2FA0 /* SwitchboardPropertiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchboardPropertiesTests.swift; sourceTree = "<group>"; };
@@ -429,6 +431,7 @@
 		D4E0606D1F82F44A00F385D3 /* Debugging */ = {
 			isa = PBXGroup;
 			children = (
+				D4EB06C82072BD88005DAACC /* Populating */,
 				D4E0606E1F82F56800F385D3 /* SwitchboardDebugControllerTests.swift */,
 			);
 			path = Debugging;
@@ -467,6 +470,14 @@
 				D4E060B61F844D0D00F385D3 /* Info.plist */,
 			);
 			path = SwitchboardDebugUITests;
+			sourceTree = "<group>";
+		};
+		D4EB06C82072BD88005DAACC /* Populating */ = {
+			isa = PBXGroup;
+			children = (
+				D4EB06C92072BDB0005DAACC /* SwitchboardPrefillControllerTests.swift */,
+			);
+			path = Populating;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -692,6 +703,7 @@
 				D4FF867D1F71D9DC003EAAC4 /* SwitchboardCacheTests.swift in Sources */,
 				D4E07F931F71B433003F5A89 /* SwitchboardDefaultStoreTests.swift in Sources */,
 				D4E07F951F71B5D5003F5A89 /* SwitchboardTests.swift in Sources */,
+				D4EB06CA2072BDB0005DAACC /* SwitchboardPrefillControllerTests.swift in Sources */,
 				D4F8A9FE20486C8B00B44DCD /* SwitchboardJSONTransformerTests.swift in Sources */,
 				D4E07F9C1F71BAE0003F5A89 /* SwitchboardSubclassTests.swift in Sources */,
 				D4E07F911F71B118003F5A89 /* SwitchboardFeatureTests.swift in Sources */,

--- a/Switchboard/Source/Debugging/Extensions/SwitchboardExperiment+Debug.swift
+++ b/Switchboard/Source/Debugging/Extensions/SwitchboardExperiment+Debug.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2017 Keepsafe Software Inc. All rights reserved.
 //
 
-#if os(iOS)
 import Foundation
 
 internal extension SwitchboardExperiment {
@@ -16,4 +15,3 @@ internal extension SwitchboardExperiment {
     }
 
 }
-#endif

--- a/Switchboard/Source/Debugging/Listing/SwitchboardDebugListView.swift
+++ b/Switchboard/Source/Debugging/Listing/SwitchboardDebugListView.swift
@@ -30,6 +30,8 @@ internal class SwitchboardDebugListView: UITableViewController {
         super.init(style: .grouped)
 
         setupView()
+        SwitchboardPrefillController.shared.populateExperimentsIfNeeded(in: debugController.switchboard,
+                                                                        analytics: debugController.analytics)
     }
 
     // MARK: - Properties

--- a/Switchboard/Source/Debugging/Populating/SwitchboardPrefillController.swift
+++ b/Switchboard/Source/Debugging/Populating/SwitchboardPrefillController.swift
@@ -14,21 +14,35 @@ final internal class SwitchboardPrefillCache: SwitchboardCache {
 
 /// Controller for adding and removing historical features and
 /// experiments used for prefilling the UI
-final internal class SwitchboardPrefillController {
+final public class SwitchboardPrefillController {
     
     // MARK: - Instantiation
     
-    static let shared = SwitchboardPrefillController()
+    public static let shared = SwitchboardPrefillController()
     
-    // MARK: - Properties
+    /// Instantiates an instance and restores any features or experiments currently cached
+    init() {
+        restoreFromCache()
+    }
+    
+    // MARK: - Internal Properties
     
     /// The features available to prefill from
-    var features = Set<SwitchboardFeature>()
+    fileprivate(set) var features = Set<SwitchboardFeature>()
     
     /// The experiments available to prefill from
-    var experiments = Set<SwitchboardExperiment>()
+    fileprivate(set) var experiments = Set<SwitchboardExperiment>()
     
-    // MARK: - API
+    // MARK: - Public API
+    
+    /// Clears all features and experiments from memory and disk
+    public func clearCache() {
+        features.removeAll()
+        experiments.removeAll()
+        SwitchboardPrefillCache.clear()
+    }
+    
+    // MARK: - Internal API
     
     /// Populates experiments from the registered experiment names within `SwitchboardExperiment`'s
     /// static property named `namesMappedToCohorts` that keeps track of programmatically named cohorts
@@ -124,6 +138,18 @@ final internal class SwitchboardPrefillController {
         cacheAll()
     }
     
+    /// Clears all features and updates cache
+    func clearFeatures() {
+        features.removeAll()
+        cacheAll()
+    }
+    
+    /// Clears all experiments and updates cache
+    func clearExperiments() {
+        experiments.removeAll()
+        cacheAll()
+    }
+    
 }
 
 // MARK: - Private API
@@ -132,6 +158,16 @@ fileprivate extension SwitchboardPrefillController {
     
     func cacheAll() {
         SwitchboardPrefillCache.cache(experiments: experiments, features: features)
+    }
+    
+    func restoreFromCache() {
+        let (experiments, features) = SwitchboardPrefillCache.restoreFromCache()
+        if let e = experiments {
+            self.experiments = e
+        }
+        if let f = features {
+            self.features = f
+        }
     }
     
 }

--- a/Switchboard/Source/Debugging/Populating/SwitchboardPrefillController.swift
+++ b/Switchboard/Source/Debugging/Populating/SwitchboardPrefillController.swift
@@ -16,10 +16,11 @@ final internal class SwitchboardPrefillCache: SwitchboardCache {
 /// experiments used for prefilling the UI
 final internal class SwitchboardPrefillController {
     
-    // MARK: - Properties
+    // MARK: - Instantiation
     
-    /// Shared instance, if needed
     static let shared = SwitchboardPrefillController()
+    
+    // MARK: - Properties
     
     /// The features available to prefill from
     var features = Set<SwitchboardFeature>()
@@ -28,6 +29,19 @@ final internal class SwitchboardPrefillController {
     var experiments = Set<SwitchboardExperiment>()
     
     // MARK: - API
+    
+    /// Populates experiments from the registered experiment names within `SwitchboardExperiment`'s
+    /// static property named `namesMappedToCohorts` that keeps track of programmatically named cohorts
+    ///
+    /// - Parameters:
+    ///   - switchboard: The `Switchboard` instance to create any new experiments within
+    ///   - analytics: An optional `SwitchboardAnalyticsProvider` to associate the experiments with
+    func populateExperimentsIfNeeded(in switchboard: Switchboard, analytics: SwitchboardAnalyticsProvider? = nil) {
+        for (experimentName, cohorts) in SwitchboardExperiment.namesMappedToCohorts {
+            guard let experiment = SwitchboardExperiment(name: experimentName, cohort: cohorts.first ?? "control", switchboard: switchboard, analytics: analytics) else { continue }
+            add(experiment: experiment)
+        }
+    }
     
     /// Checks the given array against the prefill's features to see if there are any uniques
     ///
@@ -48,16 +62,16 @@ final internal class SwitchboardPrefillController {
     /// Subtracts existing features from the prefill cache's features and returns the unique features remaining
     ///
     /// - Parameter existingFeatures: The existing features to unique from
-    /// - Returns: A unique set of features they can prefill with
+    /// - Returns: A unique set of features they can prefill with, sorted alphabetically
     func featuresUnique(from existingFeatures: [SwitchboardFeature]) -> [SwitchboardFeature] {
-        return Array(features.subtracting(existingFeatures))
+        return Array(features.subtracting(existingFeatures)).sorted(by: { $0.name < $1.name })
     }
     /// Subtracts existing experiments from the prefill cache's experiments and returns the unique experiments remaining
     ///
     /// - Parameter existingFeatures: The existing experiments to unique from
-    /// - Returns: A unique set of experiments they can prefill with
+    /// - Returns: A unique set of experiments they can prefill with, sorted alphabetically
     func experimentsUnique(from existingExperiments: [SwitchboardExperiment]) -> [SwitchboardExperiment] {
-        return Array(experiments.subtracting(existingExperiments))
+        return Array(experiments.subtracting(existingExperiments)).sorted(by: { $0.name < $1.name })
     }
     
     /// Adds the given features to the prefill cache

--- a/Switchboard/Source/Debugging/Populating/SwitchboardPrefillExperimentView.swift
+++ b/Switchboard/Source/Debugging/Populating/SwitchboardPrefillExperimentView.swift
@@ -23,6 +23,8 @@
             self.experimentSelected = experimentSelected
             
             super.init()
+            
+            refreshExperimentsToShow()
         }
         
         // MARK: - Overrides
@@ -52,6 +54,7 @@
             guard editingStyle == .delete else { return }
             
             SwitchboardPrefillController.shared.delete(experiment: experiments[indexPath.row])
+            refreshExperimentsToShow()
             tableView.reloadData()
         }
         
@@ -69,9 +72,11 @@
         fileprivate let existingExperiments: [SwitchboardExperiment]
         fileprivate let experimentSelected: SwitchboardPrefillExperimentSelected
         
-        fileprivate lazy var experiments: [SwitchboardExperiment] = { [unowned self] in
-            return SwitchboardPrefillController.shared.experimentsUnique(from: self.existingExperiments)
-        }()
+        fileprivate var experiments = [SwitchboardExperiment]()
+        
+        fileprivate func refreshExperimentsToShow() {
+            experiments = SwitchboardPrefillController.shared.experimentsUnique(from: existingExperiments)
+        }
         
         // MARK: - Unsupported Initializers
         

--- a/Switchboard/Source/Debugging/Populating/SwitchboardPrefillExperimentView.swift
+++ b/Switchboard/Source/Debugging/Populating/SwitchboardPrefillExperimentView.swift
@@ -29,7 +29,7 @@
         
         // MARK: - Overrides
         
-        override var debugTitle: String { return "Experiments" }
+        override var debugTitle: String { return "Prefill Experiments" }
         
         // MARK: - UITableViewDataSource
         
@@ -55,7 +55,11 @@
             
             SwitchboardPrefillController.shared.delete(experiment: experiments[indexPath.row])
             refreshExperimentsToShow()
-            tableView.reloadData()
+            if experiments.count == 0 {
+                dismiss(animated: true, completion: nil)
+            } else {
+                tableView.reloadData()
+            }
         }
         
         // MARK: - UITableViewDelegate

--- a/Switchboard/Source/Debugging/Populating/SwitchboardPrefillFeatureView.swift
+++ b/Switchboard/Source/Debugging/Populating/SwitchboardPrefillFeatureView.swift
@@ -29,7 +29,7 @@
         
         // MARK: - Overrides
         
-        override var debugTitle: String { return "Features" }
+        override var debugTitle: String { return "Prefill Features" }
         
         // MARK: - UITableViewDataSource
         
@@ -54,7 +54,11 @@
             
             SwitchboardPrefillController.shared.delete(feature: features[indexPath.row])
             refreshFeaturesToShow()
-            tableView.reloadData()
+            if features.count == 0 {
+                dismiss(animated: true, completion: nil)
+            } else {
+                tableView.reloadData()
+            }
         }
         
         // MARK: - UITableViewDelegate

--- a/Switchboard/Source/Debugging/Populating/SwitchboardPrefillFeatureView.swift
+++ b/Switchboard/Source/Debugging/Populating/SwitchboardPrefillFeatureView.swift
@@ -23,6 +23,8 @@
             self.featureSelected = featureSelected
             
             super.init()
+            
+            refreshFeaturesToShow()
         }
         
         // MARK: - Overrides
@@ -51,6 +53,7 @@
             guard editingStyle == .delete else { return }
             
             SwitchboardPrefillController.shared.delete(feature: features[indexPath.row])
+            refreshFeaturesToShow()
             tableView.reloadData()
         }
         
@@ -68,9 +71,11 @@
         fileprivate let existingFeatures: [SwitchboardFeature]
         fileprivate let featureSelected: SwitchboardPrefillFeatureSelected
         
-        fileprivate lazy var features: [SwitchboardFeature] = { [unowned self] in
-            return SwitchboardPrefillController.shared.featuresUnique(from: self.existingFeatures)
-        }()
+        fileprivate var features = [SwitchboardFeature]()
+        
+        fileprivate func refreshFeaturesToShow() {
+            features = SwitchboardPrefillController.shared.featuresUnique(from: existingFeatures)
+        }
         
         // MARK: - Unsupported Initializers
         

--- a/SwitchboardExample/MainViewController.swift
+++ b/SwitchboardExample/MainViewController.swift
@@ -35,6 +35,13 @@ final class MainViewController: UIViewController {
         button.addTarget(self, action: #selector(resetSwitchboard), for: .touchUpInside)
         return button
     }()
+    
+    fileprivate lazy var resetPrefillButton: UIButton = { [unowned self] in
+        let button = UIButton()
+        button.setTitle("Reset Switchboard's Prefill", for: .normal)
+        button.addTarget(self, action: #selector(resetSwitchboardPrefill), for: .touchUpInside)
+        return button
+    }()
 
     fileprivate var switchboardDebugView: SwitchboardDebugView?
 
@@ -85,6 +92,13 @@ fileprivate extension MainViewController {
                                      resetButton.trailingAnchor.constraint(equalTo: showButton.trailingAnchor),
                                      resetButton.topAnchor.constraint(equalTo: showButton.bottomAnchor),
                                      resetButton.heightAnchor.constraint(equalTo: showButton.heightAnchor)])
+        
+        resetPrefillButton.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(resetPrefillButton)
+        NSLayoutConstraint.activate([resetPrefillButton.leadingAnchor.constraint(equalTo: resetButton.leadingAnchor),
+                                     resetPrefillButton.trailingAnchor.constraint(equalTo: resetButton.trailingAnchor),
+                                     resetPrefillButton.topAnchor.constraint(equalTo: resetButton.bottomAnchor),
+                                     resetPrefillButton.heightAnchor.constraint(equalTo: resetButton.heightAnchor)])
     }
 
     // MARK: - Actions
@@ -109,6 +123,11 @@ fileprivate extension MainViewController {
         SwitchboardDebugController(switchboard: ExampleSwitchboard.shared).clearCacheAndSwitchboard()
         ExampleSwitchboard.shared.activate(serverUrlString: ExampleSwitchboard.serverUrlString, completion: nil)
         print("Switchboard has been reset back to the 'server' values")
+    }
+    
+    @objc func resetSwitchboardPrefill() {
+        SwitchboardPrefillController.shared.clearCache()
+        print("Switchboard's prefill cache has been cleared")
     }
 
     // MARK: - Refreshing

--- a/SwitchboardTests/Debugging/Populating/SwitchboardPrefillControllerTests.swift
+++ b/SwitchboardTests/Debugging/Populating/SwitchboardPrefillControllerTests.swift
@@ -1,0 +1,176 @@
+//
+//  SwitchboardPrefillControllerTests.swift
+//  SwitchboardTests
+//
+//  Created by Rob Phillips on 4/2/18.
+//  Copyright © 2018 Keepsafe Software Inc. All rights reserved.
+//
+
+#if os(iOS)
+    import XCTest
+    @testable import Switchboard
+    
+    final class SwitchboardPrefillControllerTests: XCTestCase {
+        
+        // MARK: - API
+        
+        func testClearCache() {
+            let pc = SwitchboardPrefillController()
+            addFeature(in: pc)
+            addExperiment(in: pc)
+            
+            pc.clearCache()
+            XCTAssertTrue(pc.features.isEmpty)
+            XCTAssertTrue(pc.experiments.isEmpty)
+            // Try to restore anything cached in a new controller
+            let pc2 = SwitchboardPrefillController()
+            XCTAssertTrue(pc2.features.isEmpty)
+            XCTAssertTrue(pc2.experiments.isEmpty)
+        }
+        
+        func testCachePersistsAcrossInstances() {
+            let pc = SwitchboardPrefillController()
+            clearFeatures(in: pc)
+            clearExperiments(in: pc)
+        
+            let feature = addFeature(in: pc)
+            let exp = addExperiment(in: pc)
+            
+            let pc2 = SwitchboardPrefillController()
+            XCTAssertTrue(pc2.features.contains(feature))
+            XCTAssertTrue(pc2.experiments.contains(exp))
+        }
+        
+        func testPopulatingExperimentsFromNameMapping() {
+            let pc = SwitchboardPrefillController()
+            clearExperiments(in: pc)
+            
+            SwitchboardExperiment.namesMappedToCohorts = ["populateTest": ["hai"]]
+            let switchboard = TestSwitchboardSubclass()
+            pc.populateExperimentsIfNeeded(in: switchboard)
+            XCTAssertTrue(pc.experiments.first?.name == "populateTest")
+        }
+        
+        func testCanPrefillAndUniqueFeatures() {
+            let pc = SwitchboardPrefillController()
+            clearFeatures(in: pc)
+            
+            // Test failing case
+            // (feature1 is not unique from feature1)
+            let existingFeature1 = SwitchboardFeature(name: "fail")!
+            pc.add(feature: existingFeature1)
+            XCTAssertTrue(pc.featuresUnique(from: [existingFeature1]).isEmpty)
+            XCTAssertFalse(pc.canPrefillFeatures(for: [existingFeature1]))
+            
+            // Test passing case
+            // (feature2 is unique from feature1)
+            let existingFeature2 = SwitchboardFeature(name: "pass")!
+            XCTAssertTrue(pc.canPrefillFeatures(for: [existingFeature2]))
+            XCTAssertFalse(pc.featuresUnique(from: [existingFeature2]).isEmpty)
+        }
+        
+        func testCanPrefillAndUniqueExperiments() {
+            let pc = SwitchboardPrefillController()
+            let switchboard = TestSwitchboardSubclass()
+            clearExperiments(in: pc)
+            
+            // Test failing case
+            // (exp1 is not unique from exp1)
+            let existingExp1 = SwitchboardExperiment(name: "fail", cohort: "f", switchboard: switchboard)!
+            pc.add(experiment: existingExp1)
+            XCTAssertTrue(pc.experimentsUnique(from: [existingExp1]).isEmpty)
+            XCTAssertFalse(pc.canPrefillExperiments(for: [existingExp1]))
+            
+            // Test passing case
+            // (exp2 is unique from exp1)
+            let existingExp2 = SwitchboardExperiment(name: "pass", cohort: "p", switchboard: switchboard)!
+            XCTAssertTrue(pc.canPrefillExperiments(for: [existingExp2]))
+            XCTAssertFalse(pc.experimentsUnique(from: [existingExp2]).isEmpty)
+        }
+        
+        func testAddFeatures() {
+            let pc = SwitchboardPrefillController()
+            clearFeatures(in: pc)
+            let feature1 = SwitchboardFeature(name: "addedA")!
+            let feature2 = SwitchboardFeature(name: "addedB")!
+            pc.add(features: Set([feature1, feature2]))
+            XCTAssertTrue(pc.features.contains(feature1))
+            XCTAssertTrue(pc.features.contains(feature2))
+        }
+        
+        func testAddFeature() {
+            clearFeatures()
+            addFeature()
+        }
+        
+        func testAddExperiments() {
+            let pc = SwitchboardPrefillController()
+            clearFeatures(in: pc)
+            let exp1 = SwitchboardExperiment(name: "added1", cohort: "control", switchboard: TestSwitchboardSubclass())!
+            let exp2 = SwitchboardExperiment(name: "added2", cohort: "control", switchboard: TestSwitchboardSubclass())!
+            pc.add(experiments: Set([exp1, exp2]))
+            XCTAssertTrue(pc.experiments.contains(exp1))
+            XCTAssertTrue(Array(pc.experiments).contains(exp2))
+        }
+        
+        func testAddExperiment() {
+            clearExperiments()
+            addExperiment()
+        }
+        
+        func testDeleteFeature() {
+            let pc = SwitchboardPrefillController()
+            let feature = addFeature(in: pc)
+            XCTAssertFalse(pc.features.isEmpty)
+            pc.delete(feature: feature)
+            XCTAssertTrue(pc.features.isEmpty)
+        }
+        
+        func testDeleteExperiment() {
+            let pc = SwitchboardPrefillController()
+            let exp = addExperiment(in: pc)
+            XCTAssertFalse(pc.experiments.isEmpty)
+            pc.delete(experiment: exp)
+            XCTAssertTrue(pc.experiments.isEmpty)
+        }
+        
+        func testClearFeatures() {
+            clearFeatures()
+        }
+        
+        func testClearExperiments() {
+            clearExperiments()
+        }
+        
+    }
+    
+    fileprivate extension SwitchboardPrefillControllerTests {
+        
+        @discardableResult
+        func addExperiment(in pc: SwitchboardPrefillController = SwitchboardPrefillController()) -> SwitchboardExperiment {
+            let exp1 = SwitchboardExperiment(name: "added1", cohort: "control", switchboard: TestSwitchboardSubclass())!
+            pc.add(experiment: exp1)
+            XCTAssertTrue(pc.experiments.contains(exp1))
+            return exp1
+        }
+        
+        @discardableResult
+        func addFeature(in pc: SwitchboardPrefillController = SwitchboardPrefillController()) -> SwitchboardFeature {
+            let feature1 = SwitchboardFeature(name: "added1")!
+            pc.add(feature: feature1)
+            XCTAssertTrue(pc.features.contains(feature1))
+            return feature1
+        }
+        
+        func clearExperiments(in pc: SwitchboardPrefillController = SwitchboardPrefillController()) {
+            pc.clearExperiments()
+            XCTAssertTrue(pc.experiments.isEmpty)
+        }
+        
+        func clearFeatures(in pc: SwitchboardPrefillController = SwitchboardPrefillController()) {
+            pc.clearFeatures()
+            XCTAssertTrue(pc.features.isEmpty)
+        }
+        
+    }
+#endif


### PR DESCRIPTION
Fixes #6 

### Changes

- All experiments populated using an override on `SwitchboardExperiment`'s `namesMappedToCohorts` will now auto-populate into the prefill controller so someone can explicitly add them 
  - It just requires the normal `populateAvailableCohorts()` function on each `SwitchboardExperiment` subclass to be called like normal
- Adds unit and UI tests for prefill work