### PR TITLE
Add install based experiment ID

### DIFF
--- a/Switchboard.podspec
+++ b/Switchboard.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name         = "Switchboard"
   spec.summary      = "A/B testing and feature flags for iOS built on top of Switchboard."
-  spec.version      = "0.2.2"
+  spec.version      = "0.2.3"
   spec.homepage     = "https://github.com/KeepSafe/Switchboard-iOS"
   spec.license      = { :type => "Apache 2.0", :file => "LICENSE" }
   spec.authors      = { "Keepsafe" => "rob@getkeepsafe.com" }

--- a/Switchboard/Source/SwitchboardProperties.swift
+++ b/Switchboard/Source/SwitchboardProperties.swift
@@ -23,6 +23,7 @@ public struct SwitchboardPropertyKeys {
     public static let version = "version"
     public static let build = "build"
     public static let uuid = "uuid"
+    public static let installId = "installId"
 }
 
 open class SwitchboardProperties {
@@ -40,7 +41,8 @@ open class SwitchboardProperties {
             SwitchboardPropertyKeys.country: Locale.current.regionCode ?? unknown,
             SwitchboardPropertyKeys.appId: bundleIdentifier,
             SwitchboardPropertyKeys.version: versionName,
-            SwitchboardPropertyKeys.build: buildName
+            SwitchboardPropertyKeys.build: buildName,
+            SwitchboardPropertyKeys.installId: installId
         ]
         return parameters
     }
@@ -72,6 +74,15 @@ open class SwitchboardProperties {
         #else
             return unknown
         #endif
+    }
+    private static let installIdKey = "com.keepsafe.switchboard.properties.installId"
+    /// ID generated once per install that is used to assign experiments before the user has a tracking ID/account
+    fileprivate static var installId: String {
+        if let existingId = UserDefaults.standard.string(forKey: installIdKey) { return existingId }
+
+        let generatedId = NSUUID().uuidString
+        UserDefaults.standard.set(generatedId, forKey: installIdKey)
+        return generatedId
     }
 
 }

--- a/SwitchboardTests/SwitchboardPropertiesTests.swift
+++ b/SwitchboardTests/SwitchboardPropertiesTests.swift
@@ -24,6 +24,17 @@ final class SwitchboardPropertiesTests: XCTestCase {
         XCTAssertNotNil(defaults[SwitchboardPropertyKeys.appId])
         XCTAssertNotNil(defaults[SwitchboardPropertyKeys.version])
         XCTAssertNotNil(defaults[SwitchboardPropertyKeys.build])
+        XCTAssertNotNil(defaults[SwitchboardPropertyKeys.installId])
+    }
+
+    func testInstallIdConsistency() {
+        let defaults = SwitchboardProperties.defaults(withUuid: "abcd")
+        let id = defaults[SwitchboardPropertyKeys.installId]
+        guard let installId = id as? String else { XCTFail("Install ID Nil"); return }
+        let newDefaults = SwitchboardProperties.defaults(withUuid: "bbcd")
+        let newId = newDefaults[SwitchboardPropertyKeys.installId]
+        guard let newInstallId = newId as? String else { XCTFail("Install ID Nil"); return }
+        XCTAssertEqual(installId, newInstallId)
     }
 
 }


### PR DESCRIPTION
Paired with https://github.com/KeepSafe/switchboard-backend/pull/91 this introduces install experiments. These experiments are assigned based on an ID that is generated on install and maintained for the duration of the install. 

This is for experiments like sign up flow that are conducted before the user has an account (& TID).

Thoughts or preferences on using a simple static key vs a more extensive/robust namespacing solution?